### PR TITLE
Modify fetch/execute system

### DIFF
--- a/src/cpu/Instruction.h
+++ b/src/cpu/Instruction.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <utility>
+
+#include "Opcode.h"
+
+class Instruction {
+private:
+    Opcode opcode;
+    uint8_t operand;
+    short pageBoundaryCost;
+public:
+    Instruction(Opcode opcode, uint8_t operand, short pageBoundaryCost)
+    : opcode(std::move(opcode))
+    , operand(operand)
+    , pageBoundaryCost(pageBoundaryCost) {}
+
+    const Opcode &getOpcode() const {
+        return opcode;
+    }
+
+    uint8_t getOperand() const {
+        return operand;
+    }
+
+    short getPageBoundaryCost() const {
+        return pageBoundaryCost;
+    }
+};
+

--- a/src/cpu/NesCpu.cpp
+++ b/src/cpu/NesCpu.cpp
@@ -26,7 +26,14 @@ void NesCpu::step() {
 
         // Set internal clock to instruction's step cost
         this->clock += instructionCost;
-        incrementProgramCounter();
+
+        // If instruction may have manipulated PC, do not increment.
+        // It is that instruction's responsibility to put the PC
+        // in the correct location.
+        if (!instruction.getOpcode().manipsPC) {
+            incrementProgramCounter();
+        }
+        this->programCounterOffset = 0;
     }
     // Wait until instruction's step cost is paid
     this->clock--;
@@ -146,7 +153,7 @@ uint16_t NesCpu::getOperandAddress(AddressingMode mode, short& pageBoundaryCost)
             
             break;
         case AddressingMode::ZERO_PAGE:
-            address = read(addrLoc);   // Casted uint8_t to uint16_t which is like byte $xx + zero page $0000 = $00xx
+            address = read(addrLoc);   // Cast uint8_t to uint16_t which is like byte $xx + zero page $0000 = $00xx
             this->programCounterOffset++;
             break;
         case AddressingMode::ZERO_PAGE_X:
@@ -285,5 +292,4 @@ void NesCpu::initProgramCounter() {
 
 void NesCpu::incrementProgramCounter() {
     this->programCounter += this->programCounterOffset;
-    this->programCounterOffset = 0;
 }

--- a/src/cpu/NesCpu.h
+++ b/src/cpu/NesCpu.h
@@ -27,7 +27,6 @@ private:
 	uint8_t stackPointer = STACK_POINTER_START;				// (S) Stack is stored top -> bottom ($01FF -> $0100)
 	uint16_t programCounter = 0; 							// (PC)
     uint16_t programCounterOffset = 0;                         // Amount to increment program counter at end of cycle
-    bool jumpFlag = false;                                  // True if last instruction jump/call/return
 	uint8_t* memory;										// pointer to NesSystem memory
 
 

--- a/src/cpu/NesCpu.h
+++ b/src/cpu/NesCpu.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "AbstractClockable.h"
 #include "OpcodeTable.h"
+#include "Instruction.h"
 
 
 // NOTE: The 6502 is little endian, the least significant byte comes first
@@ -25,6 +26,8 @@ private:
 	uint8_t regStatus = 0;									// (P)		byte = Negative, Overflow, _, Break, Decimal, Interrupt, Zero, Carry
 	uint8_t stackPointer = STACK_POINTER_START;				// (S) Stack is stored top -> bottom ($01FF -> $0100)
 	uint16_t programCounter = 0; 							// (PC)
+    uint16_t programCounterOffset = 0;                         // Amount to increment program counter at end of cycle
+    bool jumpFlag = false;                                  // True if last instruction jump/call/return
 	uint8_t* memory;										// pointer to NesSystem memory
 
 
@@ -33,11 +36,12 @@ private:
 	uint16_t read2Bytes(uint16_t addr);						// Little endian reads low then high then returns reordered ($00 $80 => $8000)
 	void write(uint16_t addr, uint8_t val);
 
-	uint16_t getOperandAddress(AddressingMode mode, int& pageBoundaryCost);
+	uint16_t getOperandAddress(AddressingMode mode, short& pageBoundaryCost);
 	bool isPageBoundaryCrossed(uint16_t addr1, uint16_t addr2);
+    void incrementProgramCounter();
 
-	uint8_t fetch();										// Fetches instruction (opcode) from memory pointed at by PC
-	int execute(const Opcode &opcode);		// Returns CPU cycle (step) cost of instruction
+	Instruction fetch();										// Fetches instruction (opcode) from memory pointed at by PC
+	int execute(const Instruction &instruction);		// Returns CPU cycle (step) cost of instruction
 
 
 	// Load/Store Operations

--- a/src/cpu/NesCpu.h
+++ b/src/cpu/NesCpu.h
@@ -26,7 +26,6 @@ private:
 	uint8_t regStatus = 0;									// (P)		byte = Negative, Overflow, _, Break, Decimal, Interrupt, Zero, Carry
 	uint8_t stackPointer = STACK_POINTER_START;				// (S) Stack is stored top -> bottom ($01FF -> $0100)
 	uint16_t programCounter = 0; 							// (PC)
-    uint16_t programCounterOffset = 0;                         // Amount to increment program counter at end of cycle
 	uint8_t* memory;										// pointer to NesSystem memory
 
 
@@ -37,7 +36,6 @@ private:
 
 	uint16_t getOperandAddress(AddressingMode mode, short& pageBoundaryCost);
 	bool isPageBoundaryCrossed(uint16_t addr1, uint16_t addr2);
-    void incrementProgramCounter();
 
 	Instruction fetch();										// Fetches instruction (opcode) from memory pointed at by PC
 	int execute(const Instruction &instruction);		// Returns CPU cycle (step) cost of instruction

--- a/src/cpu/Opcode.cpp
+++ b/src/cpu/Opcode.cpp
@@ -2,8 +2,6 @@
 
 #include <utility>
 
-static const std::unordered_set<std::string> pcOpCodes = {"JMP", "JSR", "BCC", "BCS", "BEQ", "BMI", "BNE", "BPL", "BVC", "BVS", "BRK", "RTI", "RTS"};
-
 Opcode::Opcode(std::string  mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles)
     // Initializer List
     : mnemonic(std::move(mnemonic))

--- a/src/cpu/Opcode.cpp
+++ b/src/cpu/Opcode.cpp
@@ -1,14 +1,15 @@
 #include "Opcode.h"
 
+#include <utility>
+
 static const std::unordered_set<std::string> pcOpCodes = {"JMP", "JSR", "BCC", "BCS", "BEQ", "BMI", "BNE", "BPL", "BVC", "BVS", "BRK", "RTI", "RTS"};
 
-Opcode::Opcode(const std::string& mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles)
+Opcode::Opcode(std::string  mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles)
     // Initializer List
-    : mnemonic(mnemonic)
+    : mnemonic(std::move(mnemonic))
     , mode(mode)
     , bytes(bytes)
-    , cycles(cycles)
-    , manipsPC(::pcOpCodes.count(mnemonic)){}
+    , cycles(cycles) {}
 
 std::string Opcode::getMnemonic() const {
     return mnemonic;

--- a/src/cpu/Opcode.cpp
+++ b/src/cpu/Opcode.cpp
@@ -5,8 +5,7 @@ Opcode::Opcode(std::string mnemonic, AddressingMode mode, uint8_t bytes, uint8_t
     : mnemonic(std::move(mnemonic))
     , mode(mode)
     , bytes(bytes)
-    , cycles(cycles)
-{}
+    , cycles(cycles) {}
 
 std::string Opcode::getMnemonic() const {
     return mnemonic;

--- a/src/cpu/Opcode.cpp
+++ b/src/cpu/Opcode.cpp
@@ -1,11 +1,14 @@
 #include "Opcode.h"
 
-Opcode::Opcode(std::string mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles)
+static const std::unordered_set<std::string> pcOpCodes = {"JMP", "JSR", "BCC", "BCS", "BEQ", "BMI", "BNE", "BPL", "BVC", "BVS", "BRK", "RTI", "RTS"};
+
+Opcode::Opcode(const std::string& mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles)
     // Initializer List
-    : mnemonic(std::move(mnemonic))
+    : mnemonic(mnemonic)
     , mode(mode)
     , bytes(bytes)
-    , cycles(cycles) {}
+    , cycles(cycles)
+    , manipsPC(::pcOpCodes.count(mnemonic)){}
 
 std::string Opcode::getMnemonic() const {
     return mnemonic;

--- a/src/cpu/Opcode.h
+++ b/src/cpu/Opcode.h
@@ -6,17 +6,12 @@
 
 class Opcode {
 private:
-    // The set of OpCodes that manipulate the program counter
-    static const std::unordered_set<std::string> pcOpCodes;
-
     std::string mnemonic;
     AddressingMode mode;
     uint8_t bytes;
     uint8_t cycles;
 public:
-    Opcode(const std::string& mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
-
-    const bool manipsPC;
+    Opcode(std::string  mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
 
     std::string getMnemonic() const;
     AddressingMode getAddressingMode() const;

--- a/src/cpu/Opcode.h
+++ b/src/cpu/Opcode.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-#include <unordered_set>
 
 #include "AddressingMode.h"
 
@@ -11,7 +10,7 @@ private:
     uint8_t bytes;
     uint8_t cycles;
 public:
-    Opcode(std::string  mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
+    Opcode(std::string mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
 
     std::string getMnemonic() const;
     AddressingMode getAddressingMode() const;

--- a/src/cpu/Opcode.h
+++ b/src/cpu/Opcode.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-#include <unordered_set>
 
 #include "AddressingMode.h"
 

--- a/src/cpu/Opcode.h
+++ b/src/cpu/Opcode.h
@@ -1,20 +1,25 @@
 #pragma once
-
 #include <string>
+#include <unordered_set>
+
 #include "AddressingMode.h"
 
 class Opcode {
+private:
+    // The set of OpCodes that manipulate the program counter
+    static const std::unordered_set<std::string> pcOpCodes;
+
+    std::string mnemonic;
+    AddressingMode mode;
+    uint8_t bytes;
+    uint8_t cycles;
 public:
-    Opcode(std::string mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
+    Opcode(const std::string& mnemonic, AddressingMode mode, uint8_t bytes, uint8_t cycles);
+
+    const bool manipsPC;
 
     std::string getMnemonic() const;
     AddressingMode getAddressingMode() const;
     uint8_t getBytes() const;
     uint8_t getCycles() const;
-
-private:
-    std::string mnemonic;
-    AddressingMode mode;
-    uint8_t bytes;
-    uint8_t cycles;
 };

--- a/src/cpu/OpcodeTable.h
+++ b/src/cpu/OpcodeTable.h
@@ -5,8 +5,8 @@
 #include "Opcode.h"
 
 class OpcodeTable {
-public:
-    static const Opcode& getOpcode(uint8_t opcode);
 private:
     static const std::unordered_map<uint8_t, Opcode> opcodeTable;
+public:
+    static const Opcode& getOpcode(uint8_t opcode);
 };

--- a/src/romparsing/Rom.h
+++ b/src/romparsing/Rom.h
@@ -15,10 +15,10 @@ private:
 public:
     Rom(INESHeader header,
         std::array<std::array<uint8_t, PRG_ROM_SIZE>, MAX_ROM_BANKS> programROMS,
-        std::array<std::array<uint8_t, PRG_ROM_SIZE>, MAX_ROM_BANKS> characterROMS):
-        header(header),
-        programROMS(programROMS),
-        characterROMS(characterROMS) {}
+        std::array<std::array<uint8_t, PRG_ROM_SIZE>, MAX_ROM_BANKS> characterROMS)
+        : header(header)
+        , programROMS(programROMS)
+        , characterROMS(characterROMS) {}
 
     const INESHeader &getHeader() const {
         return header;


### PR DESCRIPTION
Mostly changes how fetch and execute interact. Rather than
just fetching opcodes, fetch now retrieves entire instructions
including the operand that execute now carries out directly.

After some debate, I ended up relegating program counter
incrementing to the execute stage, as I feel like that more
closely matches the documentation and 6502 behavior.